### PR TITLE
add: docker support and linux fix

### DIFF
--- a/Dockerfile.siril
+++ b/Dockerfile.siril
@@ -1,23 +1,54 @@
 # syntax = docker/dockerfile:1.4
-FROM ghcr.io/astral-sh/uv:debian-slim
+FROM ghcr.io/astral-sh/uv:debian-slim as base-image
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    software-properties-common \
     git \
     cmake \
+    at-spi2-core \
+    build-essential \
+    desktop-file-utils \
+    hicolor-icon-theme \
+    intltool \
+    libgtk-3-dev \
+    libcfitsio-dev \
+    libopencv-dev \
+    libfftw3-dev \
+    libgsl-dev \
+    libjpeg-dev \
+    libtiff5-dev \
+    libpng-dev \
+    wcslib-dev \
+    libjson-glib-dev \
+    gcovr \
+    gnuplot \
+    libcurl4-gnutls-dev \
     wget \
-    tree
+    tree \
+    meson \
+    liblcms2-dev \
+    libgtksourceview-4-dev
 
-# TODO: Not working yet
-RUN add-apt-repository ppa:lock042/siril && \
-    apt-get update && \
-    apt-get install -y \
-    siril
+# RUN uv pip install --system --upgrade meson
+WORKDIR /
+
+# https://gitlab.com/free-astro/siril/-/tree/1.4.0-beta3
+RUN git clone https://gitlab.com/free-astro/siril.git siril-src
+WORKDIR /siril-src
+
+# Checkout the 1.4.0-beta3 tag (can update to something else later)
+RUN git checkout 1.4.0-beta3 && \
+    git submodule sync --recursive && \
+    git submodule update --init --recursive
+# Install the build artifact to the system
+RUN ./autogen.sh && make all install
+
 
 WORKDIR /async-siril
 COPY . /async-siril
 RUN uv sync --locked --all-extras --dev
 
 SHELL ["/bin/bash", "-c"]
-ENTRYPOINT ["uv run ./examples/test_siril.py"]
+
+# Example: change this entrypoint to run your own script
+ENTRYPOINT ["uv", "run", "./examples/test_siril.py"]

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,9 @@ format:
 generate-commands:
 	cd packages/siril-command-src && uv run export_commands.py --clean
 	cd packages/siril-command-src && uv run merge_commands.py ../../src/async_siril/command.py
-	
+
+build-docker:
+	docker build -f Dockerfile.siril -t async-siril:latest .
+
+run-docker:
+	docker run --rm -it --name siril-test async-siril:latest

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Async Siril is an asyncio based python wrapper around [Siril 1.4.0](https://www.
 * some helpers for common logic (see `async_siril.helpers`)
 * minimal dependencies (`asyncio`, `structlog`, `psutil`, `attrs`)
 * Linux, Mac, & Windows support
+* Docker support (see [Dockerfile.siril](./Dockerfile.siril))
 
 ## Requirements
 
@@ -91,6 +92,19 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+## Docker (example only)
+
+You can use the example [Dockerfile.siril](./Dockerfile.siril) to build a docker image with Siril installed. This is useful for running the examples or for running Siril commands in a container.
+
+```bash
+docker build -f Dockerfile.siril -t async-siril:latest .
+```
+
+Once built you can test the interface with this (runs `uv run ./examples/test_siril.py`):
+
+```bash
+docker run --rm -it --name siril-test async-siril:latest
+```
 
 ## Roadmap
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,7 @@
 ### Future
 * [x] exposing cgroup aware startup (for support in containerized environments)
 * [x] developer docs
-* [ ] base container image usage with Siril pre-installed (started)
+* [x] base container image usage with Siril pre-installed (started)
 * [ ] multi process support (named pipes need to be dynamic, only available on Linux)
 * [ ] multi process examples (ex. stack by filter in parallel by process)
 * [ ] make rgb cli example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,8 @@ extend-exclude = ["**/generated/*"]
 exclude = [
     "**/generated/*",
 ]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]

--- a/src/async_siril/conversion_file.py
+++ b/src/async_siril/conversion_file.py
@@ -10,6 +10,7 @@ class ConversionEntry:
     """
     Represents a single entry in a conversion file
     """
+
     original_file: pathlib.Path
     converted_file: pathlib.Path
 
@@ -19,6 +20,7 @@ class ConversionFile:
     """
     Represents a conversion file from siril as a result of the `convert` command or other sequence operations
     """
+
     entries: t.List[ConversionEntry]
     file: pathlib.Path
 

--- a/src/async_siril/event.py
+++ b/src/async_siril/event.py
@@ -13,6 +13,7 @@ class SirilEvent:
     """
     Represents an event from the Siril CLI
     """
+
     LOG = "log"
     PROGRESS = "progress"
     STATUS = "status"

--- a/src/async_siril/siril.py
+++ b/src/async_siril/siril.py
@@ -34,7 +34,7 @@ class SirilCli(object):
     async with SirilCli() as siril:
         await siril.command("stack")
     """
-    
+
     def __init__(
         self,
         siril_exe: str = "siril-cli",
@@ -214,8 +214,8 @@ class SirilCli(object):
             possible_paths.append("/Applications/Siril.app/Contents/MacOS/siril-cli")
             possible_paths.append("/Applications/Siril.app/Contents/MacOS/Siril")
         elif system == "Linux":
-            possible_paths.append("/usr/bin/siril")
-            possible_paths.append("/usr/local/bin/siril")
+            possible_paths.append("/usr/local/bin/siril-cli")
+            possible_paths.append("/usr/bin/siril-cli")
 
         for path in possible_paths:
             if os.path.exists(path):


### PR DESCRIPTION
## 📝 Description

Adding an example dockerfile for Siril.

## 🎯 Motivation and Context

Running Siril in containers supports parallelization across nodes.

## 🔍 Changes Made

- Added `Dockerfile.siril` example for compiling Siril and testing with library
- Fixed finding the correct siril executable on Linux environments
- Fixed isolation of pytests to only tests folder

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] I have added or updated tests.
- [x] I have updated the documentation if applicable.
- [x] I have linked to any relevant issues (e.g. `Fixes #123`).
- [x] All CI checks have passed locally (e.g. `make check`, `make format`, `make test`, etc).

## 🧪 Testing

`make test` passes