### PR TITLE
fix Windows siril-cli paths

### DIFF
--- a/src/async_siril/siril.py
+++ b/src/async_siril/siril.py
@@ -208,8 +208,8 @@ class SirilCli(object):
         system = platform.system()
         possible_paths = []
         if system == "Windows":
-            possible_paths.append("C:/Program Files/SiriL/bin/siril.exe")
-            possible_paths.append("C:/Program Files (x86)/SiriL/bin/siril.exe")
+            possible_paths.append("C:/msys64/mingw64/bin/siril-cli.exe") # msys2 path when building locally
+            possible_paths.append("C:/Program Files/SiriL/bin/siril-cli.exe")
         elif system == "Darwin":
             possible_paths.append("/Applications/Siril.app/Contents/MacOS/siril-cli")
             possible_paths.append("/Applications/Siril.app/Contents/MacOS/Siril")

--- a/src/async_siril/siril.py
+++ b/src/async_siril/siril.py
@@ -208,7 +208,7 @@ class SirilCli(object):
         system = platform.system()
         possible_paths = []
         if system == "Windows":
-            possible_paths.append("C:/msys64/mingw64/bin/siril-cli.exe") # msys2 path when building locally
+            possible_paths.append("C:/msys64/mingw64/bin/siril-cli.exe")  # msys2 path when building locally
             possible_paths.append("C:/Program Files/SiriL/bin/siril-cli.exe")
         elif system == "Darwin":
             possible_paths.append("/Applications/Siril.app/Contents/MacOS/siril-cli")


### PR DESCRIPTION
## 📝 Description

Removes "C:/Program Files (x86)" which is never targetted by the installer 
Uses headless exe (siril-cli.exe)
Adds msys2/MinGW64 path for users building locally (made it the preferred choice)

## 🎯 Motivation and Context

See #4 

## 🔍 Changes Made

As listed

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] I have added or updated tests.
- [ ] I have updated the documentation if applicable.
- [x] I have linked to any relevant issues (e.g. `Fixes #123`).
- [x] All CI checks have passed locally (e.g. `make check`, `make format`, `make test`, etc).

## 🧪 Testing

```
C:\Astro\async-siril> make test                                                                                                                                                                                        
uv run pytest                                                                                                                                                                                                                 
==================================================================================================== test session starts ==================================================================================================== 
platform win32 -- Python 3.12.7, pytest-8.4.1, pluggy-1.6.0                                                                                                                                                                   
rootdir: C:\Astro\async-siril                                                                                                                                                                                             
configfile: pyproject.toml                                                                                                                                                                                                    
testpaths: tests                                                                                                                                                                                                              
collected 55 items                                                                                                                                                                                                            

tests\test_calibrate_command.py .......                                                                                                                                                                                [ 12%]
tests\test_register_command.py .......                                                                                                                                                                                 [ 25%] 
tests\test_simple_postprocessing_commands.py ...........................                                                                                                                                               [ 74%]
tests\test_simple_preprocessing_commands.py ..........                                                                                                                                                                 [ 92%]
tests\test_stack_command.py ....                       

============================================================================================== 55 passed, 41 warnings in 0.66s ============================================================================================== 
```

Getting warnings about wrong escape (41 of them), unrelated to this PR:

```
src\async_siril\command.py:172
  C:\Astro\async-siril\src\async_siril\command.py:172: SyntaxWarning: invalid escape sequence '\*'
    """
```

## 📎 Related Issues

Fixes #4

---

