### PR TITLE
add: allow easier set of non-persistent setting

### DIFF
--- a/examples/calibrate_light.py
+++ b/examples/calibrate_light.py
@@ -54,6 +54,7 @@ class CalibrateLight:
             log.info(f"temp dir: {temp}")
 
             async with SirilCli(directory=self.raw_folder) as siril:
+                # Caution: these settings are saved between Siril sessions
                 await siril.command(setext(self.ext))
                 await siril.command(set32bits())
 

--- a/examples/create_master_bias.py
+++ b/examples/create_master_bias.py
@@ -34,6 +34,7 @@ class CreateMasterBias:
             log.info(f"temp dir: {temp}")
 
             async with SirilCli(directory=self.raw_folder) as siril:
+                # Caution: these settings are saved between Siril sessions
                 await siril.command(setext(self.ext))
                 await siril.command(set32bits())
 

--- a/examples/create_master_dark.py
+++ b/examples/create_master_dark.py
@@ -43,6 +43,7 @@ class CreateMasterDark:
             log.info(f"temp dir: {temp}")
 
             async with SirilCli(directory=self.raw_folder) as siril:
+                # Caution: these settings are saved between Siril sessions
                 await siril.command(setext(self.ext))
                 await siril.command(set32bits())
 

--- a/examples/create_master_flat.py
+++ b/examples/create_master_flat.py
@@ -37,6 +37,7 @@ class CreateMasterFlat:
             log.info(f"temp dir: {temp}")
 
             async with SirilCli(directory=self.raw_folder) as siril:
+                # Caution: these settings are saved between Siril sessions
                 await siril.command(setext(self.ext))
                 await siril.command(set32bits())
 

--- a/examples/create_master_light.py
+++ b/examples/create_master_light.py
@@ -58,6 +58,7 @@ class CreateMasterLight:
             rejection = BestRejection.find(list(self.pp_folder.glob(f"*.{self.ext.value}")))
 
             async with SirilCli(directory=self.pp_folder) as siril:
+                # Caution: these settings are saved between Siril sessions
                 await siril.command(setext(self.ext))
                 await siril.command(set32bits())
 

--- a/examples/test_siril.py
+++ b/examples/test_siril.py
@@ -6,7 +6,8 @@ import asyncio
 import cappa
 
 from async_siril.siril import SirilCli
-from async_siril.command import set32bits
+from async_siril.command import get
+from async_siril.command_types import SirilSetting
 from rich.prompt import Confirm
 
 log = structlog.stdlib.get_logger()
@@ -18,7 +19,8 @@ class TestSiril:
         log.info("Testing Siril Interface")
 
         async with SirilCli() as siril:
-            await siril.command(set32bits())
+            await siril.set(SirilSetting.FORCE_16BIT, False)
+            await siril.command(get(list_all=True))
             Confirm.ask("Continue")
 
         log.info("Siril Interface completed")

--- a/src/async_siril/command.py
+++ b/src/async_siril/command.py
@@ -46,6 +46,7 @@ from .command_types import (
     psf_method,
     manual_psf_method,
     sequence_filter_type,
+    SirilSetting,
 )
 
 
@@ -4177,14 +4178,17 @@ class set(BaseCommand):
     def __init__(
         self,
         import_file: t.Optional[str] = None,
-        key: t.Optional[str] = None,
-        value: t.Optional[str] = None,
+        key: t.Optional[str | SirilSetting] = None,
+        value: t.Optional[str | bool] = None,
     ):
         super().__init__()
         if import_file is not None:
             self.append(CommandOption("import", import_file))
         if key is not None and value is not None:
-            self.append(CommandArgument(f"{key}={value}"))
+            if isinstance(key, SirilSetting):
+                self.append(CommandArgument(f"{key.value}={value}"))
+            else:
+                self.append(CommandArgument(f"{key}={value}"))
         else:
             raise ValueError("key and value must be provided")
 

--- a/src/async_siril/command_types.py
+++ b/src/async_siril/command_types.py
@@ -4,6 +4,16 @@ from enum import Enum
 from dataclasses import dataclass
 
 
+class SirilSetting(Enum):
+    """Represents some of the common Siril settings, use `get -a` to discover more."""
+
+    EXTENSION = "core.extension"
+    FORCE_16BIT = "core.force_16bit"
+    MEM_MODE = "core.mem_mode"
+    MEM_AMOUNT = "core.mem_amount"
+    MEM_RATIO = "core.mem_ratio"
+
+
 @dataclass
 class Rect:
     x: int


### PR DESCRIPTION
## 📝 Description

Provide a partial / simple way to set non-persistent settings.

## 🎯 Motivation and Context

As @cissou8 informed me, the `set32bits()` commands persist to the config file and is not a default behavior I intended for the library so a new SirilSetting enum was introduced for the common settings and the main Siril processes uses this way to set memory mode so that it doesn't conflict with a users settings from the GUI.

## 🔍 Changes Made

- Added `siril.set(...)` which is an abstraction around the `set` command.
- Updated examples to caution against persistent settings.

## ✅ Checklist

- [x] My code follows the code style of this project.
- [x] I have added or updated tests.
- [x] I have updated the documentation if applicable.
- [x] I have linked to any relevant issues (e.g. `Fixes #123`).
- [x] All CI checks have passed locally (e.g. `make check`, `make format`, `make test`, etc).

## 🧪 Testing

`make check, test and format all pass`

## 📎 Related Issues

Addresses issue #3 

---

